### PR TITLE
Pad rectangular matrices with 0 instead of max value

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -27,7 +27,7 @@ func ToSquare(m [][]int) [][]int {
 			if i < rowsLen && j < colsLen {
 				matrix[i][j] = m[i][j]
 			} else {
-				matrix[i][j] = MaxValue
+				matrix[i][j] = 0
 			}
 
 		}

--- a/matrix_test.go
+++ b/matrix_test.go
@@ -24,8 +24,8 @@ func TestVerticalMatrixToSquare(t *testing.T) {
 	verticalMatrix[1] = []int{1}
 
 	expectedMatrix := newMatrix(2, 2)
-	expectedMatrix[0] = []int{1, lapjv.MaxValue}
-	expectedMatrix[1] = []int{1, lapjv.MaxValue}
+	expectedMatrix[0] = []int{1, 0}
+	expectedMatrix[1] = []int{1, 0}
 
 	result := lapjv.ToSquare(verticalMatrix)
 
@@ -38,7 +38,7 @@ func TestHorizontalMatrixToSquare(t *testing.T) {
 
 	expectedMatrix := newMatrix(2, 2)
 	expectedMatrix[0] = []int{1, 2}
-	expectedMatrix[1] = []int{lapjv.MaxValue, lapjv.MaxValue}
+	expectedMatrix[1] = []int{0, 0}
 
 	result := lapjv.ToSquare(horizontalMatrix)
 


### PR DESCRIPTION
We do not need to use the max value when padding matrices, using 0 achieves the same goal and solving is a lot more efficient.